### PR TITLE
feat: Exit Codes

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,8 +53,8 @@ type Conversation struct {
 func main() {
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	if apiKey == "" {
-		fmt.Println("Please set `OPENAI_API_KEY` environment variable. You can find your API key at https://platform.openai.com/account/api-keys.")
-		return
+		fmt.Fprintln(os.Stderr, "Please set `OPENAI_API_KEY` environment variable. You can find your API key at https://platform.openai.com/account/api-keys.")
+		os.Exit(1)
 	}
 
 	home, err := homedir.Dir()


### PR DESCRIPTION
Closes #4

Not sure if you want to add this anywhere else in the code, but if the API key is not set, you now get exit 1.
